### PR TITLE
Fix link rendering in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ The main benefits of using Nix over `stack` are:
 
     Nix is a powerful tool in the hands of advanced users.  You can make very
     deep and sweeping changes to your toolchain, such as recompiling everything
-    with security hardening 
+    with security hardening
 
 The main disadvantage of using Nix over `stack` are:
 
@@ -73,8 +73,8 @@ The main disadvantage of using Nix over `stack` are:
 
     The public binary cache only caches OS X packages for unstable nixpkgs releases.
     If you try to use a stable NixOS release you will spend hours building GHC
-    multiple times since Nix bootstraps GHC starting [all the way from GHC 7.4]
-    (https://github.com/NixOS/nixpkgs/issues/19926)
+    multiple times since Nix bootstraps GHC starting
+    [all the way from GHC 7.4](https://github.com/NixOS/nixpkgs/issues/19926)
 
 *   Verbosity
 


### PR DESCRIPTION
GitHub Flavored Markdown doesn't appear to like links that span multiple lines. This fixes it by squishing it all on one line.