### PR TITLE
Update README.md

### DIFF
--- a/project0/README.md
+++ b/project0/README.md
@@ -334,7 +334,7 @@ This references another file in this same project called `default.nix`.  This
 file was generated using `cabal2nix` by running:
 
 ```bash
-$ cabal2nix . > default.nix
+$ cabal2nix ./. > default.nix
 ```
 
 ... and the generated `default.nix` file for this project is:


### PR DESCRIPTION
cabal2nix will not produce a working value for the src attribute if given `.` It works if you give it `./.` which is a legal path in nix