### PR TITLE
It is time to celebrate&update release 16.09 -> 18.09

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ The main disadvantage of using Nix over `stack` are:
 Both Nix and `stack` use curated package sets instead of version bounds for
 dependency management.  `stack` calls these package sets "resolvers" whereas
 Nix calls these package sets "channels".  Nix provides stable channels with
-names like `NixOS-16.09` (analogous to `stack`'s LTS releases) and then an
+names like `NixOS-18.09` (analogous to `stack`'s LTS releases) and then an
 unstable channel named `nixpkgs-unstable` (analogous to `stack`'s nightly
 releases)
 

--- a/project0/README.md
+++ b/project0/README.md
@@ -232,7 +232,7 @@ nixpkgs https://nixos.org/channels/nixpkgs-unstable
 
 ```bash
 $ sudo nix-channel --list
-nixos https://nixos.org/channels/nixos-16.09
+nixos https://nixos.org/channels/nixos-18.09
 ```
 
 You should probably use the default channel selected for you.  If you are using
@@ -240,11 +240,11 @@ a Linux operating system other than NixOS, you can safely change to a stable
 channel if you prefer by running:
 
 ```bash
-$ nix-channel --add https://nixos.org/channels/nixos-16.09-small nixpkgs
+$ nix-channel --add https://nixos.org/channels/nixos-18.09-small nixpkgs
 $ nix-channel --update nixpkgs
 ```
 
-... replacing `16.09` with whatever stable release version you wish to use.
+... replacing `18.09` with whatever stable release version you wish to use.
 
 However, you should be very careful about using a stable release on OS X because
 the public binary cache only caches OS X build products for the unstable

--- a/project1/README.md
+++ b/project1/README.md
@@ -71,13 +71,13 @@ You can find the latest curated package set here:
 
 ... which corresponds roughly to the `nixpkgs-unstable` release.  If you would
 like to see what package versions Nix selects for a stable release such as
-`nixos-16.09`, then change the branch name in the URL from `master` to
-`release-16.09`, like this:
+`nixos-18.09`, then change the branch name in the URL from `master` to
+`release-18.09`, like this:
 
-* [Curated Hackage package set for NixOS-16.09][hackage-packages-16.09]
+* [Curated Hackage package set for NixOS-18.09][hackage-packages-18.09]
 
 These curated package sets correspond roughly to Stackage resolvers.  Stable
-releases like `nixos-16.09` correspond to Stackage LTS resolvers, and
+releases like `nixos-18.09` correspond to Stackage LTS resolvers, and
 the `nixpkgs-unstable` release corresponds roughly to a Stackage nightly
 resolver.  The main difference is that Nix's package set curation extends beyond
 Haskell packages: `nixpkgs` also curates non-Haskell dependencies, too.
@@ -710,4 +710,4 @@ This concludes basic dependency management in Nix.  The
 dependencies.
 
 [hackage-packages]: https://raw.githubusercontent.com/NixOS/nixpkgs/master/pkgs/development/haskell-modules/hackage-packages.nix
-[hackage-packages-16.09]: https://raw.githubusercontent.com/NixOS/nixpkgs/release-16.09/pkgs/development/haskell-modules/hackage-packages.nix
+[hackage-packages-18.09]: https://raw.githubusercontent.com/NixOS/nixpkgs/release-18.09/pkgs/development/haskell-modules/hackage-packages.nix


### PR DESCRIPTION
NixOS is maturing as a good wine. Two years, change a version, and all lines are still true today.