### PR TITLE
README: readlink release.nix and rm result

### DIFF
--- a/project0/README.md
+++ b/project0/README.md
@@ -103,7 +103,7 @@ We can verify this by removing the symlink and then performing the build again:
 
 ```bash
 $ rm result -rf
-$ nix-build release
+$ nix-build release0.nix
 $ readlink result
 /nix/store/x28vx2rfnffl1clmxn5054bxwqyln2j0-project0-1.0.0
 ```

--- a/project0/README.md
+++ b/project0/README.md
@@ -102,8 +102,9 @@ rebuild of our project.
 We can verify this by removing the symlink and then performing the build again:
 
 ```bash
-$ rm result
-$ nix-build release0.nix
+$ rm result -rf
+$ nix-build release
+$ readlink result
 /nix/store/x28vx2rfnffl1clmxn5054bxwqyln2j0-project0-1.0.0
 ```
 


### PR DESCRIPTION
The expression in the README was `nix-build release0.nix` which does not show the symlink of the result. Also, removing `result` requires the `-rf` flag.