### PR TITLE
fix mismatch between writeup and code samples

### DIFF
--- a/project3/release0.nix
+++ b/project3/release0.nix
@@ -3,10 +3,7 @@ let
     packageOverrides = pkgs: rec {
       haskellPackages = pkgs.haskellPackages.override {
         overrides = haskellPackagesNew: haskellPackagesOld: rec {
-          project3 =
-            haskellPackagesNew.callPackage ./project3.nix {
-              tar = pkgs.libtar;
-            };
+          morte = pkgs.haskell.lib.dontHaddock haskellPackagesOld.morte;
         };
       };
     };
@@ -15,5 +12,5 @@ let
   pkgs = import <nixpkgs> { inherit config; };
 
 in
-  { project3 = pkgs.haskellPackages.project3;
+  { morte = pkgs.haskellPackages.morte;
   }


### PR DESCRIPTION
project3/README.md shows a code listing for release0.nix that does not
match the actual contents of that file. This commit fixes that mismatch
by changing the file to match the listing shown in the README.